### PR TITLE
Added chain.id into residue name

### DIFF
--- a/RamachanDraw/phi_psi.py
+++ b/RamachanDraw/phi_psi.py
@@ -14,7 +14,7 @@ def phi_psi(pdb_file, return_ignored=False):
                 peptides = PPBuilder().build_peptides(chain)
                 for peptide in peptides:
                     for aa, angles in zip(peptide, peptide.get_phi_psi_list()):
-                        residue = aa.resname + str(aa.id[1])
+                        residue = chain.id + ":" + aa.resname + str(aa.id[1])
                         output[residue] = angles
 
         for key, value in output.items():


### PR DESCRIPTION
This carries the chain information into the phi_psi dictionary to help with identifying residues when multiple chains have the same residue in the same position.